### PR TITLE
Change dependency on home director

### DIFF
--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -27,14 +27,16 @@ RUN pip install --no-cache-dir --upgrade pip && \
 RUN groupadd -g 1000 user && \
     useradd -ms /bin/bash -u 1000 -g 1000 user && \
     mkdir -p /opt/rucio/etc/ && \
-    chown -R user:user /opt/rucio/etc/
+    chown -R user:user /opt/rucio/etc/ && \
+    mkdir -p /opt/user && \
+    chown user:user /opt/user
 
 USER user
 WORKDIR /home/user
 
 # Add the configuration template and enable bash completion for the rucio clients
-ADD --chown=user:user rucio.cfg.j2 /home/user/rucio.cfg.j2
-ADD --chown=user:user bashrc /home/user/.bashrc
+ADD --chown=user:user rucio.cfg.j2 /opt/user/rucio.cfg.j2
+ADD init_rucio.sh /etc/profile.d/rucio_init.sh
 
 ENV PATH $PATH:/opt/rucio/bin
 

--- a/clients/Dockerfile_py3
+++ b/clients/Dockerfile_py3
@@ -22,18 +22,21 @@ RUN python3.6 -m pip install --no-cache-dir --upgrade pip && \
     python3.6 -m pip install --no-cache-dir --pre rucio-clients==$TAG && \
     python3.6 -m pip install --no-cache-dir jinja2 j2cli pyyaml
 
+
 # Add a separate user and change ownership of config dir to that user
 RUN groupadd -g 1000 user && \
     useradd -ms /bin/bash -u 1000 -g 1000 user && \
     mkdir -p /opt/rucio/etc/ && \
-    chown -R user:user /opt/rucio/etc/
+    chown -R user:user /opt/rucio/etc/ && \
+    mkdir -p /opt/user && \
+    chown user:user /opt/user
 
 USER user
 WORKDIR /home/user
 
 # Add the configuration template and enable bash completion for the rucio clients
-ADD --chown=user:user rucio.cfg.j2 /home/user/rucio.cfg.j2
-ADD --chown=user:user bashrc /home/user/.bashrc
+ADD --chown=user:user rucio.cfg.j2 /opt/user/rucio.cfg.j2
+ADD init_rucio.sh /etc/profile.d/rucio_init.sh
 
 ENV PATH $PATH:/opt/rucio/bin
 

--- a/clients/init_rucio.sh
+++ b/clients/init_rucio.sh
@@ -7,7 +7,7 @@ shopt -s checkwinsize
 if [ ! -f /opt/rucio/etc/rucio.cfg ]; then
     echo "File rucio.cfg not found. It will generate one."
     mkdir -p /opt/rucio/etc/
-    j2 rucio.cfg.j2 > /opt/rucio/etc/rucio.cfg
+    j2 /opt/user/rucio.cfg.j2 > /opt/rucio/etc/rucio.cfg
 fi
 
 echo "Enable shell completion on the rucio commands"


### PR DESCRIPTION
I propose some changes to your pull request to make Singularity work as well. The issue with the previous setup was that /home gets automatically mounted in in Singularity, so anything that is put there will basically not be available inside a Singularity container. 

I tested this works in Singularity. I have to admit I didn't fully test the functionality in Docker. 